### PR TITLE
Save combined lidar frame

### DIFF
--- a/Simulation/sensors.py
+++ b/Simulation/sensors.py
@@ -36,7 +36,7 @@ class Sensors:
                 'type': 'sensor.lidar.ray_cast',
                 'transform': {'x': 0.7, 'y': 0.0, 'z': 1.6, 'roll': 0.0, 'pitch': 0.0, 'yaw': 0.0},
                 'attributes': {
-                    'range': 50, 'rotation_frequency': 20, 'channels': 64,
+                    'range': 50, 'rotation_frequency': 20, 'channels': 128,
                     'upper_fov': 4, 'lower_fov': -20, 'points_per_second': 2304000
                 },
                 'id': 'LIDAR'
@@ -139,28 +139,6 @@ class Sensors:
                     f"(Vehicle ID {vehicle_id}): {len(points)} points. "
                     f"Distance to Ego: {vehicles_in_radius[vehicle_id][1]:.2f}m."
                 )
-            
-            """# Log all keys and first 10 points of each dataset in lidar_data_buffer
-            with lidar_data_lock:
-                logging.info("Current LIDAR data buffer state:")
-                for key, value in lidar_data_buffer.items():
-                    logging.info(f"Sensor ID {key}: Data type is {type(value)}")
-                    try:
-                        if isinstance(value, memoryview):
-                            logging.info(f"Sensor ID {key}: Converting memoryview to NumPy array.")
-                            points_array = np.frombuffer(value, dtype=np.float32).reshape(-1, 4)
-                        elif isinstance(value, bytes):
-                            points_array = np.frombuffer(value, dtype=np.float32).reshape(-1, 4)
-                        else:
-                            logging.warning(f"Sensor ID {key}: Data type not recognized, skipping detailed log.")
-                            continue
-                        
-                        # Log the first 10 points
-                        logging.info(
-                            f"Sensor ID {key}: First 10 points: {points_array[:10].tolist() if len(points_array) >= 10 else points_array.tolist()}"
-                        )
-                    except Exception as e:
-                        logging.error(f"Error processing LIDAR data for Sensor ID {key}: {e}")"""
 
         except AttributeError as e:
             logging.error(f"AttributeError in LIDAR callback for Sensor ID {sensor_id}: {e}")

--- a/utils/proximity_mapping.py
+++ b/utils/proximity_mapping.py
@@ -5,6 +5,8 @@ import json
 from threading import Lock, Thread
 from math import sqrt
 import time
+import os, cv2
+import numpy as np
 
 from utils.compression import DataCompressor
 
@@ -84,7 +86,6 @@ class ProximityMapping:
                 logging.error(f"Error retrieving sensor ID {sensor_id} for {vehicle_label}: {e}")
         return None  # Return None if no LIDAR sensor is found
 
-
     def send_data_to_ego(self, ego_address, smart_vehicle_id, smart_vehicle, vehicle_mapping, lidar_data_buffer, lidar_data_lock):
         """
         Sends the full pose data (position, rotation, speed, and LIDAR) from the smart vehicle to the ego vehicle.
@@ -126,6 +127,10 @@ class ProximityMapping:
         if lidar_data:
             if isinstance(lidar_data, memoryview):
                 lidar_data = list(lidar_data)
+
+            # Convert LiDAR data into NumPy format for visualization
+            lidar_points = np.frombuffer(bytearray(lidar_data), dtype=np.float32).reshape(-1, 4)
+
             # Log the type of lidar_data before serialization
             # logging.info(f"Type of lidar_data before serialization: {type(lidar_data)}")
             logging.info(f"Sending LIDAR data from {vehicle_label} to Ego Vehicle: {len(lidar_data)} points.")


### PR DESCRIPTION
lidar data combined successfully in streamed data

## Summary by Sourcery

Add functionality to project and save LiDAR data as 2D frames, and enhance LiDAR data processing by increasing the number of channels.

New Features:
- Introduce functionality to project LiDAR points onto a 2D image plane and save the resulting frames.

Enhancements:
- Increase the number of LiDAR channels from 64 to 128 for improved data capture.